### PR TITLE
fix(puppet_modules): :adhesive_bandage: latest modules do not need to be printed

### DIFF
--- a/src/puppet_module.rs
+++ b/src/puppet_module.rs
@@ -120,7 +120,7 @@ impl std::fmt::Display for PuppetModule {
                 self.current_version,
                 self.latest_version.to_string().blue()
             ),
-            None => write!(f, "{} {}", self.name, self.current_version),
+            None => write!(f, ""),
         }
     }
 }


### PR DESCRIPTION
Fixes #8